### PR TITLE
Fix: Error when importing SampleChunkResource with no SCA parameters

### DIFF
--- a/blender/__init__.dev.py
+++ b/blender/__init__.dev.py
@@ -11,7 +11,7 @@ bl_info = {
     "name": "Hedgehog Engine I/O DEV BUILD",
     "author": "Justin113D, hedge-dev",
     "description": "Import/Exporter for Hedgehog Engine 3D related formats",
-    "version": (0, 1, 130),
+    "version": (1, 0, 1),
     "blender": (4, 2, 0),
     "doc_url": "https://hedge-dev.github.io/HedgehogEngineBlenderIO/",
     "tracker_url": "https://github.com/hedge-dev/HedgehogEngineBlenderIO/issues/new",

--- a/blender/blender_manifest.dev.toml
+++ b/blender/blender_manifest.dev.toml
@@ -1,7 +1,7 @@
 schema_version = "1.0.0"
 
 id = "hedgehog_engine_io_dev"
-version = "0.1.130"
+version = "1.0.1"
 name = "Hedgehog Engine I/O DEV BUILD"
 tagline = "Import/Exporter for Hedgehog Engine 3D related formats"
 maintainer = "Justin113D, hedge-dev"

--- a/blender/source/importing/i_node.py
+++ b/blender/source/importing/i_node.py
@@ -142,7 +142,7 @@ class NodeConverter:
             return
 
         c_node = HEIONET.sample_chunk_node_find(model_info.c_mesh_data_set.sample_chunk_node_root, "NodesExt")
-        if c_node is None:
+        if not c_node:
             return
         
         current_child = c_node.contents.child


### PR DESCRIPTION
Some models have Sample chunk nodes but no SCA parameters. These ran into an incorrect nullpointer check during model conversion.