### PR TITLE
Fix HedgeDocs page links in Manual

### DIFF
--- a/manual/source/getting_started/about.rst
+++ b/manual/source/getting_started/about.rst
@@ -6,7 +6,7 @@ About HEIO
 The `Hedgehog Engine Blender I/O Addon <https://github.com/hedge-dev/HedgehogEngineBlenderIO>`_,
 short "**HEIO**", is an addon for `Blender <https://www.blender.org/>`_, adding the ability to
 import and export 3D related file formats used by
-`Hedgehog Engine and Hedgehog Engine 2 games <https://hedgedocs.com/docs/hedgehog-engine/gamelist/>`_.
+`Hedgehog Engine and Hedgehog Engine 2 games <https://hedgedocs.com/index.php/Games>`_.
 
 The addon is a free open source tool primarily maintained by `Justin113D <https://justin113d.com/>`_,
 powered by the `SharpNeedle <https://github.com/hedge-dev/SharpNeedle>`_ C# Library.

--- a/manual/source/tutorials/shadow_gens_stage_mod.rst
+++ b/manual/source/tutorials/shadow_gens_stage_mod.rst
@@ -31,7 +31,7 @@ Part 0: The tools
 Before we begin, you should make sure you have all the tools needed:
 
 - :doc:`Installing HEIO </getting_started/installation>` for... well, HEIO
-- `HedgeArcPack <https://hedgedocs.com/tools/hedgehog-engine/common/files/>`_ for unpacking and packing archive files
+- `HedgeArcPack <https://hedgedocs.com/index.php/HedgeArcPack>`_ for unpacking and packing archive files
 - `HedgeModManager <https://github.com/thesupersonic16/HedgeModManager>`_ for running the mod
 - `Sonic X Shadow Generations <https://store.steampowered.com/app/2513280>`_ (should be obvious why)
 
@@ -73,7 +73,7 @@ there. Inside that directory, you are met with many more directories and ``.pac`
 of them are named after the actual stage names! what now?
 
 Sonic Team organizes the stage by the zone and act (or challenge) numbers, which are documented
-`here <https://hedgedocs.com/docs/hedgehog-engine/miller/levels/ids/>`_. Going by that list,
+`here <https://hedgedocs.com/index.php/Shadow_Generations_Stage_IDs>`_. Going by that list,
 Kingdom Valley Act 1 should be stored under ``w03a10``.
 
 Inside that directory you will find more ``.pac`` files, which is exactly what we are looking for!


### PR DESCRIPTION
Certain pages of the manual were written before the HedgeDocs rework, and as such, still contained outdated links that didn't function on the current HedgeDocs iteration. This simple PR just corrects the handful of links in the manual to make them point to the correct places again.